### PR TITLE
Fixes PCA9685 lockup during Init

### DIFF
--- a/src/PCA9685.c
+++ b/src/PCA9685.c
@@ -54,7 +54,7 @@ int PCA9685_initPWM(int fd, unsigned char addr, unsigned int freq) {
 
   // send a software reset to get defaults 
   unsigned char resetval = _PCA9685_RESETVAL;
-  unsigned char mode1val = 0x00 | _PCA9685_AUTOINCBIT;
+  unsigned char mode1val = 0x00 | _PCA9685_AUTOINCBIT | _PCA9685_ALLCALLBIT | _PCA9685_SUB3BIT | _PCA9685_SUB2BIT | _PCA9685_SUB1BIT;
 
   ret = _PCA9685_writeI2CRaw(fd, _PCA9685_MODE1REG, 1, &resetval);
   if (ret != 0) {

--- a/src/PCA9685.h
+++ b/src/PCA9685.h
@@ -21,8 +21,13 @@ extern "C" {
 #define _PCA9685_PRESCALEREG	0xFE
 
 // bit positions within MODE1 register
+#define _PCA9685_ALLCALLBIT	0x01
+#define _PCA9685_SUB3BIT	0x02
+#define _PCA9685_SUB2BIT	0x04
+#define _PCA9685_SUB1BIT	0x08
 #define _PCA9685_SLEEPBIT	0x10
 #define _PCA9685_AUTOINCBIT	0x20
+#define _PCA9685_EXTCLKBIT	0x40
 #define _PCA9685_RESTARTBIT	0x80
 
 // control register to initiate device reset


### PR DESCRIPTION
as discussed in Issue #1 

After 0x20 was written to mode1reg my PCA9685 device became inaccessible. Enabling the SUB[1-3] and ALLCALL bits fixed the issue for me.

While I was at it I added definitions for the remaining couple bits (currently unused).

Thanks!