### PR TITLE
SUBADRx bits should not be used by default

### DIFF
--- a/src/PCA9685.c
+++ b/src/PCA9685.c
@@ -56,7 +56,7 @@ int PCA9685_initPWM(int fd, unsigned char addr, unsigned int freq) {
 
   // send a software reset to get defaults 
   unsigned char resetval = _PCA9685_RESETVAL;
-  unsigned char mode1val = 0x00 | _PCA9685_AUTOINCBIT | _PCA9685_ALLCALLBIT | _PCA9685_SUB3BIT | _PCA9685_SUB2BIT | _PCA9685_SUB1BIT;
+  unsigned char mode1val = 0x00 | _PCA9685_AUTOINCBIT | _PCA9685_ALLCALLBIT; 
 
   ret = _PCA9685_writeI2CRaw(fd, _PCA9685_MODE1REG, 1, &resetval);
   if (ret != 0) {


### PR DESCRIPTION
When I "fixed" my lockup problem in #2 I added the sub address bits (_PCA9685_SUB[1-3]BIT) but I should not have.

After running init with these set the PCA9685 sets more I²C addresses.

My device's base address is 0x70, here is output from `i2cdetect -y 1` before init with those bits set:
```
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: UU -- -- -- -- -- -- -- 48 -- -- -- -- -- -- -- 
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
70: 70 -- -- -- -- -- -- --                         
```

And here is what I see after running init:
```
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: UU -- -- -- -- -- -- -- 48 -- -- -- -- -- -- -- 
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
70: 70 71 72 -- 74 -- -- -- 
```

(The device at 0x48 is a temp sensor and is not relevant to this issue)

Removing the SUB bits prevents this, but I still need the ALLCALL bit set for my device to work.

(TODO: I would like to add the use of the SUB bits, as it would be nice to have groups so I can control certain zones of lights together!)