### PR TITLE
Changed CMake min version to 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.0)
 project(PCA9685)
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.0)
 project (libPCA9685)
 
 set (libPCA9685_VERSION_MAJOR 0)


### PR DESCRIPTION
Hi!

I kinda blew up my Pi last night, so today I am using this with a NextThing CHIP and the version of CMake on it is 3.0.2. I really didn't feel like compiling CMake from source to upgrade it, and I don't see anything that you're doing here that wouldn't be fine with 3.x.

Tested, and it works great! As an added bonus, you now know that it can work fine on devices other than a Pi. :)