### PR TITLE
Added PCA9685_MODE1_opts() - Issue #15

### DIFF
--- a/examples/PCA9685demo/PCA9685demo.c
+++ b/examples/PCA9685demo/PCA9685demo.c
@@ -66,6 +66,13 @@ int initHardware(int adpt, int addr, int freq) {
     return -1;
   } // if 
 
+  // test settting mode1 register
+  ret = PCA9685_MODE1_opts(fd, addr, 0x00 | _PCA9685_AUTOINCBIT);
+  if (ret != 0) {
+    fprintf(stderr, "initHardware(): PCA9685_MODE1_opts() returned %d\n", ret);
+    return -1;
+  } // if
+
   if (debug) {
     // display all used pca registers 
     ret = PCA9685_dumpAllRegs(fd, addr);

--- a/src/PCA9685.c
+++ b/src/PCA9685.c
@@ -110,6 +110,22 @@ int PCA9685_initPWM(int fd, unsigned char addr, unsigned int freq) {
 } // PCA9685_initPWM
 
 
+/////////////////////////////////////////////////////////////////////
+// set the mode1 register. Only required to set non-default bits
+int PCA9685_MODE1_opts(int fd, unsigned char addr, unsigned char val) {
+  int ret;
+
+  // write the value to the MODE1 register
+  ret = _PCA9685_writeI2CReg(fd, addr, _PCA9685_MODE1REG, 1, &val);
+  if (ret != 0) {
+    printf("PCA9685_MODE1_opts(): _PCA9685_writeI2CReg() returned ");
+    printf("%d on addr %02x\n", ret, _PCA9685_MODE1REG);
+    return -1;
+  } // if
+
+  return 0;
+} // PCA9685_MODE1_opts
+
 
 /////////////////////////////////////////////////////////////////////
 // set all PWM OFF vals in one transaction 

--- a/src/PCA9685.c
+++ b/src/PCA9685.c
@@ -60,7 +60,7 @@ int PCA9685_initPWM(int fd, unsigned char addr, unsigned int freq) {
 
   // send a software reset to get defaults 
   unsigned char resetval = _PCA9685_RESETVAL;
-  unsigned char mode1val = 0x00 | _PCA9685_AUTOINCBIT | _PCA9685_ALLCALLBIT; 
+  unsigned char mode1val = 0x00 | _PCA9685_AUTOINCBIT ; 
 
   ret = _PCA9685_writeI2CRaw(fd, _PCA9685_MODE1REG, 1, &resetval);
   if (ret != 0) {

--- a/src/PCA9685.h
+++ b/src/PCA9685.h
@@ -55,6 +55,9 @@ int PCA9685_openI2C(unsigned char adpt, unsigned char addr);
 // initialize a pca device to defaults, turn off PWM's, and set the freq
 int PCA9685_initPWM(int fd, unsigned char addr, unsigned int freq);
 
+// set the mode1 register to override default settings
+int PCA9685_MODE1_opts(int fd, unsigned char addr, unsigned char val);
+
 // set all PWM channels from two arrays of ON and OFF vals in one transaction
 int PCA9685_setPWMVals(int fd, unsigned char addr,
                        unsigned int* onVals, unsigned int* offVals);


### PR DESCRIPTION
As per #15 

Added:
`int PCA9685_MODE1_opts(int fd, unsigned char addr, unsigned char val);`

Also added a simple test in PCA9685demo.c which simply sets the value to 0x00 | AUTOINC
Tested by setting it to ALLCALL and then clearing it