### PR TITLE
allow setting all mode1 and mode2 options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 - **CMakeLists.txt**: setup cmake at top level and in src/, use versioning in lib and apps
 - **.travis.yml**: setup Travis CI
 - **Config.h.in**: templates for Config.h headers that get cmake version values
-- **PCA9685demo.c**: print key menu
+- **PCA9685demo.c**: print key menu in ncurses mode
+- **PCA9685demo.c**: add many command line options, add -h usage msg
+- **PCA9685.h**: added externs for MODE1 and MODE2 options and define all bits
 
 ### Changed
 - **PCA9685demo.c**: change #define constants to getopt vars
@@ -17,6 +19,7 @@
 - **PCA9685.c**: change #define DEBUG to extern int \_PCA9685_DEBUG
 - **PCA9685.c**: remove SUBnBITs from mode1val
 - **PCA9685.c**: fix debug logs
+- **PCA9685.c**: use externs for MODE1 and MODE2
 - **PCA9685.h**: add extern int \_PCA9685_DEBUG
 
 ### Removed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.0)
 project(PCA9685)
 
 
+# add flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra")
+
+
 # build the library
 add_subdirectory (src)
 include_directories ("${PROJECT_SOURCE_DIR}/src")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(PCA9685)
 
 
 # add flags
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra")
+set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} -D_BSD_SOURCE -std=c11 -Wall -pedantic -Wextra")
 
 
 # build the library

--- a/README.md
+++ b/README.md
@@ -170,6 +170,26 @@ VARIABLES
         example: `_PCA9685_DEBUG = 1; // enable debugging output`
 
 
+        ----------------------------------------------------------------
+        extern unsigned char _PCA9685_MODE1;
+        ----------------------------------------------------------------
+        0x11 (default):  AUTOINC and SLEEP set (hardware default)
+        non-default:     set or clear bits defined in PCA9685.h
+
+        example: `_PCA9685_MODE1 = _PCA9685_MODE1 | _PCA9685_SUB1BIT;
+                  // enable respond to i2c subaddress 1`
+
+
+        ----------------------------------------------------------------
+        extern unsigned char _PCA9685_MODE2;
+        ----------------------------------------------------------------
+        0x04 (default):  OUTDRV set to use totem pole (hardware default)
+        non-default:     set or clear bits defined in PCA9685.h
+
+        example: `_PCA9685_MODE2 = _PCA9685_MODE2 & ~_PCA9685_OUTDRVBIT;
+                  // switch from totem pole to open drain mode
+
+
 FUNCTIONS
 
         Most projects will only require the first three functions below
@@ -249,5 +269,6 @@ FUNCTIONS
 TODO
 
         test suite
-        MODE1 and MODE2 options
+        cleanup fd and addr handling
+        all errors to stdout
         dev locking?

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ VARIABLES
         non-default:     set or clear bits defined in PCA9685.h
 
         example: `_PCA9685_MODE2 = _PCA9685_MODE2 & ~_PCA9685_OUTDRVBIT;
-                  // switch from totem pole to open drain mode
+                  // switch from totem pole to open drain mode`
 
 
 FUNCTIONS

--- a/examples/PCA9685demo/PCA9685demo.c
+++ b/examples/PCA9685demo/PCA9685demo.c
@@ -266,13 +266,15 @@ struct rgb hsv2rgb(struct hsv _hsv) {
 
 // main driver 
 int main(int argc, char **argv) {
-  fprintf(stdout, "PCA9685demo %d.%d\n", PCA9685demo_VERSION_MAJOR, PCA9685demo_VERSION_MINOR);
   // parse command line options
   int c;
   opterr = 0;
-  while ((c = getopt (argc, argv, "dnv")) != -1)
+  while ((c = getopt (argc, argv, "hVdnva123ozOkN")) != -1)
     switch (c)
       {
+      case 'V':  // version
+        fprintf(stdout, "PCA9685demo %d.%d\n", PCA9685demo_VERSION_MAJOR, PCA9685demo_VERSION_MINOR);
+        exit(0);
       case 'd':  // debug mode
         debug = 1;
         _PCA9685_DEBUG = 1;
@@ -283,6 +285,57 @@ int main(int argc, char **argv) {
       case 'v':  // validate mode
         validate = 1;
         break;
+      case 'a':  // ALLCALL mode
+        _PCA9685_MODE1 = _PCA9685_MODE1 | _PCA9685_ALLCALLBIT;
+        break;
+      case '1':  // SUBADDR1 mode
+        _PCA9685_MODE1 = _PCA9685_MODE1 | _PCA9685_SUB1BIT;
+        break;
+      case '2':  // SUBADDR2 mode
+        _PCA9685_MODE1 = _PCA9685_MODE1 | _PCA9685_SUB2BIT;
+        break;
+      case '3':  // SUBADDR3 mode
+        _PCA9685_MODE1 = _PCA9685_MODE1 | _PCA9685_SUB3BIT;
+        break;
+      case 'o':  // output disabled, LEDn depends on output driver mode
+        _PCA9685_MODE2 = _PCA9685_MODE2 & ~_PCA9685_OUTNE1BIT | _PCA9685_OUTNE0BIT;
+        break;
+      case 'z':  // output disabled, LEDn = high impedence
+        _PCA9685_MODE2 = _PCA9685_MODE2 | _PCA9685_OUTNE1BIT;
+        break;
+      case 'O':  // open drain
+        _PCA9685_MODE2 = _PCA9685_MODE2 & ~_PCA9685_OUTDRVBIT;
+        break;
+      case 'k':  // change on ack
+        _PCA9685_MODE2 = _PCA9685_MODE2 | _PCA9685_OCHBIT;
+        break;
+      case 'N':  // inverted output
+        _PCA9685_MODE2 = _PCA9685_MODE2 | _PCA9685_INVRTBIT;
+        break;
+      case 'h':  // help mode
+        printf("Usage:\n");
+        printf("  %s [options]\n", argv[0]);
+        printf("Options:\n");
+        printf("  -h\thelp, show this screen and quit\n");
+        printf("  -V\tVersion, print the program name and version and quit\n");
+        printf("  -d\tdebug, shows internal function calls and parameter values\n");
+        printf("  -n\tncurses, for interactive operation\n");
+        printf("  -v\tvalidate, read back register values and compare to written values\n");
+        printf("  -a\tallcall, device will respond to i2c all call address\n");
+        printf("  -1\tsub1, device will respond to i2c subaddress 1\n");
+        printf("  -2\tsub2, device will respond to i2c subaddress 2\n");
+        printf("  -3\tsub3, device will respond to i2c subaddress 3\n");
+        printf("  -o\toutput disabled,\n");
+        printf("    \t  LEDn = 1 in default totem pole mode,\n");
+        printf("    \t  LEDn = high impedence in open-drain mode\n");
+        printf("    \t  instead of default LEDn = 0\n");
+        printf("  -z\toutput disabled, LEDn = high impedence\n");
+        printf("    \t  instead of default LEDn = 0\n");
+        printf("  -O\topen drain, instead of default totem pole\n");
+        printf("  -k\tack change, instead of default stop change\n");
+        printf("  -N\tinvert output\n");
+        printf("Use only one of -o or -z to override the default output disabled mode.\n");
+        exit(0);
       }
 
   int adpt = 1;

--- a/examples/PCA9685demo/PCA9685demo.c
+++ b/examples/PCA9685demo/PCA9685demo.c
@@ -298,7 +298,7 @@ int main(int argc, char **argv) {
         _PCA9685_MODE1 = _PCA9685_MODE1 | _PCA9685_SUB3BIT;
         break;
       case 'o':  // output disabled, LEDn depends on output driver mode
-        _PCA9685_MODE2 = _PCA9685_MODE2 & ~_PCA9685_OUTNE1BIT | _PCA9685_OUTNE0BIT;
+        _PCA9685_MODE2 = (_PCA9685_MODE2 & ~_PCA9685_OUTNE1BIT) | _PCA9685_OUTNE0BIT;
         break;
       case 'z':  // output disabled, LEDn = high impedence
         _PCA9685_MODE2 = _PCA9685_MODE2 | _PCA9685_OUTNE1BIT;

--- a/examples/quickstart/quickstart.c
+++ b/examples/quickstart/quickstart.c
@@ -15,7 +15,7 @@ int addr = 0x40;
 void intHandler(int dummy) {
   // turn off all channels
   PCA9685_setAllPWM(fd, addr, _PCA9685_MINVAL, _PCA9685_MINVAL);
-  exit(0);
+  exit(dummy);
 }
 
 
@@ -26,7 +26,7 @@ int initHardware(int adpt, int addr, int freq) {
 }
 
 
-int main(int argc, char **argv) {
+int main(void) {
   fprintf(stdout, "quickstart %d.%d\n", quickstart_VERSION_MAJOR, quickstart_VERSION_MINOR);
   int adpt = 1;
   int freq = 200;

--- a/src/PCA9685.c
+++ b/src/PCA9685.c
@@ -11,10 +11,12 @@
 #include "PCA9685.h"
 #include "libPCA9685Config.h"
 
-//#define INVERT
-//#define OPENDRAIN
-
+// debug flag
 int _PCA9685_DEBUG = 0;
+// mode1 value hardware defaults (all call and sleep)
+unsigned char _PCA9685_MODE1 = 0x00 | _PCA9685_ALLCALLBIT | _PCA9685_SLEEPBIT;
+// mode2 value hardware defaults (totem pole mode)
+unsigned char _PCA9685_MODE2 = 0x00 | _PCA9685_OUTDRVBIT;
 
 /////////////////////////////////////////////////////////////////////
 // open the I2C bus device and assign the default slave address 
@@ -60,8 +62,6 @@ int PCA9685_initPWM(int fd, unsigned char addr, unsigned int freq) {
 
   // send a software reset to get defaults 
   unsigned char resetval = _PCA9685_RESETVAL;
-  unsigned char mode1val = 0x00 | _PCA9685_AUTOINCBIT | _PCA9685_ALLCALLBIT;
-
   ret = _PCA9685_writeI2CRaw(fd, _PCA9685_MODE1REG, 1, &resetval);
   if (ret != 0) {
     fprintf(stderr, "PCA9685_initPWM(): _PCA9685_writeI2CRaw() returned %d\n", ret);
@@ -84,7 +84,10 @@ int PCA9685_initPWM(int fd, unsigned char addr, unsigned int freq) {
     return -1;
   } // if 
 
-  // set MODE1 register
+  // set MODE1 register using default value with AUTOINC
+  // and without any of SLEEP, EXTCLK, and RESTART
+  unsigned char mode1val = _PCA9685_MODE1 | _PCA9685_AUTOINCBIT;
+  mode1val = mode1val & ~_PCA9685_SLEEPBIT & ~_PCA9685_EXTCLKBIT & ~_PCA9685_RESTARTBIT;
   ret = _PCA9685_writeI2CReg(fd, addr, _PCA9685_MODE1REG, 1, &mode1val);
   if (ret != 0) {
     fprintf(stderr, "PCA9685_initPWM(): _PCA9685_writeI2CReg() returned ");
@@ -92,19 +95,14 @@ int PCA9685_initPWM(int fd, unsigned char addr, unsigned int freq) {
     return -1;
   } // if 
 
-  #ifdef OPENDRAIN
   // set MODE2 register
-  unsigned char mode2val = 0x00 & ~_PCA9685_OUTDRVBIT;
-  #ifdef INVERT
-  mode2val = mode2val | _PCA9685_INVRTBIT;
-  #endif
+  unsigned char mode2val = _PCA9685_MODE2;
   ret = _PCA9685_writeI2CReg(fd, addr, _PCA9685_MODE2REG, 1, &mode2val);
   if (ret != 0) {
     fprintf(stderr, "PCA9685_initPWM(): _PCA9685_writeI2CReg() returned ");
     fprintf(stderr, "%d on addr %02x\n", ret, addr);
     return -1;
   } // if 
-  #endif
 
   return 0;
 } // PCA9685_initPWM

--- a/src/PCA9685.h
+++ b/src/PCA9685.h
@@ -3,6 +3,8 @@ extern "C" {
 #endif
 
 extern int _PCA9685_DEBUG;
+extern unsigned char _PCA9685_MODE1;
+extern unsigned char _PCA9685_MODE2;
 
 #ifndef _PCA9685_H
 #define _PCA9685_H
@@ -34,8 +36,11 @@ extern int _PCA9685_DEBUG;
 #define _PCA9685_RESTARTBIT	0x80
 
 // bit positions within MODE2 register
-#define _PCA9685_INVRTBIT	0x10
+#define _PCA9685_OUTNE0BIT	0x01
+#define _PCA9685_OUTNE1BIT	0x02
 #define _PCA9685_OUTDRVBIT	0x04
+#define _PCA9685_OCHBIT 	0x08
+#define _PCA9685_INVRTBIT	0x10
 
 // control register to initiate device reset
 #define _PCA9685_RESETVAL	0x06

--- a/test/PCA9685test.c
+++ b/test/PCA9685test.c
@@ -87,7 +87,6 @@ int testFailWriteAllChannels() {
       _PCA9685_MAXVAL, _PCA9685_MAXVAL, _PCA9685_MAXVAL, _PCA9685_MAXVAL,
       _PCA9685_MAXVAL, _PCA9685_MAXVAL, _PCA9685_MAXVAL, _PCA9685_MAXVAL,
       _PCA9685_MAXVAL, _PCA9685_MAXVAL, _PCA9685_MAXVAL, _PCA9685_MAXVAL };
-  int i;
   int rc = PCA9685_setPWMVals(ffd, addr, setOnVals, setOffVals);
   if (rc == 0) {
     fprintf(stderr, "ERROR: testFailWriteAllChannels: PCA9685_setPWMVals(%d, 0x%02x, NULL, setOffVals) returned %d\n", fd, addr, rc);
@@ -144,13 +143,13 @@ int main(int argc, char **argv) {
   long ladpt = strtol(argv[1], NULL, 16);
   long laddr = strtol(argv[2], NULL, 16);
   if (ladpt > INT_MAX || ladpt < 0) {
-    fprintf(stderr, "ERROR: adapter number %s is not valid\n", ladpt);
+    fprintf(stderr, "ERROR: adapter number %ld is not valid\n", ladpt);
     exit(-1);
   } // if ladpt
   adpt = ladpt;
 
   if (laddr > INT_MAX || laddr < 0) {
-    fprintf(stderr, "ERROR: address %s is not valid\n", laddr);
+    fprintf(stderr, "ERROR: address 0x%02lx is not valid\n", laddr);
     exit(-1);
   } // if laddr
   addr = laddr;

--- a/test/PCA9685test.c
+++ b/test/PCA9685test.c
@@ -144,13 +144,13 @@ int main(int argc, char **argv) {
   long ladpt = strtol(argv[1], NULL, 16);
   long laddr = strtol(argv[2], NULL, 16);
   if (ladpt > INT_MAX || ladpt < 0) {
-    fprintf(stderr, "ERROR: adapter number %s is not valid\n");
+    fprintf(stderr, "ERROR: adapter number %s is not valid\n", ladpt);
     exit(-1);
   } // if ladpt
   adpt = ladpt;
 
   if (laddr > INT_MAX || laddr < 0) {
-    fprintf(stderr, "ERROR: address %s is not valid\n");
+    fprintf(stderr, "ERROR: address %s is not valid\n", laddr);
     exit(-1);
   } // if laddr
   addr = laddr;


### PR DESCRIPTION
PCA9685.h: add externs for MODE1 and MODE2, define all bits
PCA9685.c: assign hardware defaults to MODE1 and MODE2,
in initPWM, always set AUTOINC and always clear SLEEP, EXTCLK, and RESET,
and always set MODE2, remove #ifdefs
PCA9685demo.c: add opts for configuring MODE1 and MODE2,
add -h usage message and -V version number